### PR TITLE
Fix "undefined method `github`" called when using other RequestSource

### DIFF
--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -44,6 +44,12 @@ module Danger
     # @return   [Boolean]
     attr_accessor :test_summary
 
+    # Defines a RequestSource object for html/markdown formatting method calls.
+    # Defaults to `github`.
+    # @param    [RequestSource] value
+    # @return   [RequestSource]
+    attr_accessor :repo_provider
+
     def project_root
       root = @project_root || Dir.pwd
       root += '/' unless root.end_with? '/'
@@ -60,6 +66,10 @@ module Danger
 
     def test_summary
       @test_summary .nil? ? true : @test_summary
+    end
+
+    def repo_provider
+      @repo_provider || github
     end
 
     # Reads a file with JSON Xcode summary and reports it.
@@ -116,7 +126,7 @@ module Danger
       clean_path, line = parse_filename(path)
       path = clean_path + '#L' + line if clean_path && line
 
-      github.html_link(path)
+      repo_provider.html_link(path)
     end
 
     def parse_filename(path)

--- a/spec/fixtures/bitbucket_pr.json
+++ b/spec/fixtures/bitbucket_pr.json
@@ -1,0 +1,14 @@
+{
+	"fromRef": {
+		"repository": {
+			"links": {
+				"self": [
+					{
+						"href": "https://github.com/diogot/danger-xcode_summary"
+					}
+				]
+			}
+		},
+		"latestCommit": "4d4c0f31857e3185b51b6865a0700525bc0cb2bb"
+	}
+}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,8 +52,23 @@ def testing_env
   }
 end
 
+def testing_bitbucket_env
+  {
+    'GIT_URL' => 'https://github.com/diogot/danger-xcode_summary.git',
+    'JENKINS_URL' => 'http://jenkins.server.com/',
+    'DANGER_BITBUCKETCLOUD_USERNAME' => 'username',
+    'DANGER_BITBUCKETCLOUD_PASSWORD' => 'password'
+  }
+end
+
 # A stubbed out Dangerfile for use in tests
 def testing_dangerfile
   env = Danger::EnvironmentManager.new(testing_env)
+  Danger::Dangerfile.new(env, testing_ui)
+end
+
+# A stubbed out Dangerfile with Bitbucket as a request_source for use in tests
+def testing_bitbucket_dangerfile
+  env = Danger::EnvironmentManager.new(testing_bitbucket_env)
   Danger::Dangerfile.new(env, testing_ui)
 end

--- a/spec/xcode_summary_spec.rb
+++ b/spec/xcode_summary_spec.rb
@@ -95,5 +95,26 @@ module Danger
         end
       end
     end
+
+    # Second environment with different request_source
+    describe 'with bitbucket request_source' do
+      before do
+        @dangerfile = testing_bitbucket_dangerfile
+        @xcode_summary = @dangerfile.xcode_summary
+        # rubocop:disable LineLength
+        @xcode_summary.env.request_source.pr_json = JSON.parse(IO.read('spec/fixtures/bitbucket_pr.json'), symbolize_names: true)
+        # rubocop:enable LineLength
+        @xcode_summary.project_root = '/Users/diogo/src/danger-xcode_summary'
+      end
+
+      describe 'where request source' do
+        it 'should be bitbucket' do
+          path = @xcode_summary.send(:format_path, 'lib/xcode_summary/plugin.rb#L3')
+          # rubocop:disable LineLength
+          expect(path).to eq "<a href='https://github.com/diogot/danger-xcode_summary/lib/xcode_summary/plugin.rb?at=4d4c0f31857e3185b51b6865a0700525bc0cb2bb#L3'>lib/xcode_summary/plugin.rb</a>"
+          # rubocop:enable LineLength
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes the next crash while using BitbucketServer as RequestSource in Dangerfile:
```
[!] The exception involves the following plugins:
 -  danger-xcode_summary
bundler: failed to load command: danger (/var/_xcsbuildd/gems/ruby/2.0.0/bin/danger)
Danger::DSLError:
[!] Invalid `Dangerfile` file: undefined method `github' for #<Danger::Dangerfile:0x007fc00990a850>. Updating the Danger gem might fix the issue. Your Danger version: 4.0.0, latest Danger version: 4.0.1
 #  from Dangerfile:30
 #  -------------------------------------------
 #  # Generate a summary from xcodebuild report
 >  xcode_summary.report ENV['XCS_XCODEBUILD_LOG']
 #  
 #  -------------------------------------------

  /var/_xcsbuildd/gems/ruby/2.0.0/bundler/gems/danger-d02a2f2d4159/lib/danger/danger_core/dangerfile.rb:68:in `method_missing'
  /var/_xcsbuildd/gems/ruby/2.0.0/bundler/gems/danger-d02a2f2d4159/lib/danger/plugin_support/plugin.rb:23:in `method_missing'
  /var/_xcsbuildd/gems/ruby/2.0.0/gems/danger-xcode_summary-0.1.0/lib/xcode_summary/plugin.rb:105:in `format_path'
  /var/_xcsbuildd/gems/ruby/2.0.0/gems/danger-xcode_summary-0.1.0/lib/xcode_summary/plugin.rb:135:in `format_compile_warning'
  /var/_xcsbuildd/gems/ruby/2.0.0/gems/danger-xcode_summary-0.1.0/lib/xcode_summary/plugin.rb:86:in `block in warnings'
  /var/_xcsbuildd/gems/ruby/2.0.0/gems/danger-xcode_summary-0.1.0/lib/xcode_summary/plugin.rb:86:in `map'
  /var/_xcsbuildd/gems/ruby/2.0.0/gems/danger-xcode_summary-0.1.0/lib/xcode_summary/plugin.rb:86:in `warnings'
  /var/_xcsbuildd/gems/ruby/2.0.0/gems/danger-xcode_summary-0.1.0/lib/xcode_summary/plugin.rb:72:in `format_summary'
  /var/_xcsbuildd/gems/ruby/2.0.0/gems/danger-xcode_summary-0.1.0/lib/xcode_summary/plugin.rb:62:in `report'
  Dangerfile:30:in `block in parse'
  /var/_xcsbuildd/gems/ruby/2.0.0/bundler/gems/danger-d02a2f2d4159/lib/danger/danger_core/dangerfile.rb:199:in `eval'
  /var/_xcsbuildd/gems/ruby/2.0.0/bundler/gems/danger-d02a2f2d4159/lib/danger/danger_core/dangerfile.rb:199:in `block in parse'
  /var/_xcsbuildd/gems/ruby/2.0.0/bundler/gems/danger-d02a2f2d4159/lib/danger/danger_core/dangerfile.rb:195:in `instance_eval'
  /var/_xcsbuildd/gems/ruby/2.0.0/bundler/gems/danger-d02a2f2d4159/lib/danger/danger_core/dangerfile.rb:195:in `parse'
  /var/_xcsbuildd/gems/ruby/2.0.0/bundler/gems/danger-d02a2f2d4159/lib/danger/danger_core/dangerfile.rb:272:in `run'
  /var/_xcsbuildd/gems/ruby/2.0.0/bundler/gems/danger-d02a2f2d4159/lib/danger/danger_core/executor.rb:27:in `run'
  /var/_xcsbuildd/gems/ruby/2.0.0/bundler/gems/danger-d02a2f2d4159/lib/danger/commands/runner.rb:66:in `run'
  /var/_xcsbuildd/gems/ruby/2.0.0/gems/claide-1.0.1/lib/claide/command.rb:334:in `run'
  /var/_xcsbuildd/gems/ruby/2.0.0/bundler/gems/danger-d02a2f2d4159/bin/danger:5:in `<top (required)>'
  /var/_xcsbuildd/gems/ruby/2.0.0/bin/danger:22:in `load'
  /var/_xcsbuildd/gems/ruby/2.0.0/bin/danger:22:in `<top (required)>'
```

p.s.: Ruby is not a language I know well so any advice about "how you shouldn't write in Ruby" could be helpful.