### PR TITLE
Updating compile warning line to be optional

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'danger'
-gem 'yard'
 gem 'rubocop'
+gem 'yard'

--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -133,10 +133,16 @@ module Danger
       return nil if should_ignore_warning?(path)
 
       path_link = format_path(path)
-      "**#{path_link}**: #{escape_reason(h[:reason])}  <br />" \
-        "```\n" \
-        "#{h[:line]}\n" \
-        '```'
+
+      warning = "**#{path_link}**: #{escape_reason(h[:reason])}  <br />"
+      if h[:line] && h[:line].empty? == false
+        "#{warning}" \
+          "```\n" \
+          "#{h[:line]}\n" \
+          '```'
+      else
+        warning
+      end
     end
 
     def format_format_file_missing_error(h)

--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -135,7 +135,7 @@ module Danger
       path_link = format_path(path)
 
       warning = "**#{path_link}**: #{escape_reason(h[:reason])}  <br />"
-      if h[:line] && h[:line].empty? == false
+      if h[:line] && !h[:line].empty?
         "#{warning}" \
           "```\n" \
           "#{h[:line]}\n" \

--- a/spec/fixtures/summary_with_empty_line.json
+++ b/spec/fixtures/summary_with_empty_line.json
@@ -1,0 +1,37 @@
+{
+  "warnings": [
+
+  ],
+  "ld_warnings": [
+
+  ],
+  "compile_warnings": [
+    {
+      "file_name": "AppDelegate.swift",
+      "file_path": "/Users/marcelofabri/Developer/MyAwesomeProject/MyAwesomeProject/Classes/AppDelegate.swift:10001:",
+      "reason": "File should contain 400 lines or less: currently contains 10001",
+      "line": "",
+      "cursor": "^"
+    }
+  ],
+  "errors": [
+
+  ],
+  "compile_errors": [
+
+  ],
+  "file_missing_errors": [
+
+  ],
+  "undefined_symbols_errors": [
+
+  ],
+  "duplicate_symbols_errors": [
+
+  ],
+  "tests_failures": {
+  },
+  "tests_summary_messages": [
+    "\t Executed 4 tests, with 0 failures (0 unexpected) in 0.012 (0.017) seconds\n"
+  ]
+}

--- a/spec/xcode_summary_spec.rb
+++ b/spec/xcode_summary_spec.rb
@@ -51,6 +51,15 @@ module Danger
           ]
         end
 
+        it 'formats compile warnings with empty line' do
+          @xcode_summary.report('spec/fixtures/summary_with_empty_line.json')
+          expect(@dangerfile.status_report[:warnings]).to eq [
+            # rubocop:disable LineLength
+            "**<a href='https://github.com/diogot/danger-xcode_summary/blob/129jef029jf029fj2039fj203f92/Users/marcelofabri/Developer/MyAwesomeProject/MyAwesomeProject/Classes/AppDelegate.swift#L10001'>/Users/marcelofabri/Developer/MyAwesomeProject/MyAwesomeProject/Classes/AppDelegate.swift#L10001</a>**: File should contain 400 lines or less: currently contains 10001  <br />"
+            # rubocop:enable LineLength
+          ]
+        end
+
         it 'ignores file when ignored_files matches' do
           @xcode_summary.ignored_files = '**/Pods/**'
           @xcode_summary.report('spec/fixtures/summary.json')


### PR DESCRIPTION
When running SwiftLint, some warnings have no line, e.g.:
>File should contain 400 lines or less: currently contains 517 