### PR TITLE
Allow hiding the test summary messages

### DIFF
--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -38,6 +38,12 @@ module Danger
     # @return   [Boolean]
     attr_accessor :sticky_summary
 
+    # Defines if the build summary is shown or not.
+    # Defaults to `true`.
+    # @param    [Boolean] value
+    # @return   [Boolean]
+    attr_accessor :test_summary
+
     def project_root
       root = @project_root || Dir.pwd
       root += '/' unless root.end_with? '/'
@@ -50,6 +56,10 @@ module Danger
 
     def sticky_summary
       @sticky_summary || false
+    end
+
+    def test_summary
+      @test_summary .nil? ? true : @test_summary
     end
 
     # Reads a file with JSON Xcode summary and reports it.
@@ -74,9 +84,13 @@ module Danger
     end
 
     def messages(xcode_summary)
-      [
-        xcode_summary[:tests_summary_messages]
-      ].flatten.uniq.compact.map(&:strip)
+      if test_summary
+        [
+          xcode_summary[:tests_summary_messages]
+        ].flatten.uniq.compact.map(&:strip)
+      else
+        []
+      end
     end
 
     def warnings(xcode_summary)

--- a/spec/xcode_summary_spec.rb
+++ b/spec/xcode_summary_spec.rb
@@ -28,17 +28,32 @@ module Danger
         expect(@xcode_summary.sticky_summary).to eq false
       end
 
+      it 'sets test_summary to true as default' do
+        expect(@xcode_summary.test_summary).to eq true
+      end
+
       it 'fail if file does not exist' do
         @xcode_summary.report('spec/fixtures/inexistent_file.json')
         expect(@dangerfile.status_report[:errors]).to eq ['summary file not found']
       end
 
       describe 'summary' do
-        it 'formats summary messages' do
-          @xcode_summary.report('spec/fixtures/summary_messages.json')
-          expect(@dangerfile.status_report[:messages]).to eq [
-            'Executed 4 tests, with 0 failures (0 unexpected) in 0.012 (0.017) seconds'
-          ]
+        context 'enabled' do
+          it 'formats summary messages' do
+            @xcode_summary.test_summary = true
+            @xcode_summary.report('spec/fixtures/summary_messages.json')
+            expect(@dangerfile.status_report[:messages]).to eq [
+              'Executed 4 tests, with 0 failures (0 unexpected) in 0.012 (0.017) seconds'
+            ]
+          end
+        end
+
+        context 'disabled' do
+          it 'shows no summary messages' do
+            @xcode_summary.test_summary = false
+            @xcode_summary.report('spec/fixtures/summary_messages.json')
+            expect(@dangerfile.status_report[:messages]).to eq []
+          end
         end
 
         it 'formats compile warnings' do


### PR DESCRIPTION
Introduce a `test_summary` accessor which configures wether to show the test summary messages or not.

These messages will be hidden when `test_summary = false`:

![image](https://cloud.githubusercontent.com/assets/98880/23552284/5908fbb2-001b-11e7-9272-07d4a25a940c.png)
