### PR TITLE
Implement inline_mode

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -80,6 +80,9 @@ Style/RedundantSelf:
 Metrics/MethodLength:
   Max: 60
 
+Metrics/ModuleLength:
+  Enabled: false
+
 # We're not there yet
 Style/Documentation:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -105,6 +105,15 @@ xcode_summary.ignored_files = '**/Pods/**'
 xcode_summary.report 'xcodebuild.json'
 ```
 
+You can use `inline_mode`.
+When this value is enabled, each warnings and errors are commented on each lines.
+
+```ruby
+# Comment on each lines
+xcode_summary.inline_mode = true
+xcode_summary.report 'xcodebuild.json'
+```
+
 ## License
 
 danger-xcode_summary is released under the MIT license. See [LICENSE.txt](LICENSE.txt) for details.

--- a/danger-xcode_summary.gemspec
+++ b/danger-xcode_summary.gemspec
@@ -1,5 +1,7 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
+
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'xcode_summary/gem_version.rb'
 

--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -19,8 +19,8 @@ module Danger
   # @tags xcode, xcodebuild, format
   #
   class DangerXcodeSummary < Plugin
-    Struct.new("Location", :file_name, :file_path, :line)
-    Struct.new("Result", :message, :location)
+    Struct.new('Location', :file_name, :file_path, :line)
+    Struct.new('Result', :message, :location)
 
     # The project root, which will be used to make the paths relative.
     # Defaults to `pwd`.
@@ -123,22 +123,32 @@ module Danger
       [
         xcode_summary.fetch(:warnings, []).map { |message| Struct::Result.new(message, nil) },
         xcode_summary.fetch(:ld_warnings, []).map { |message| Struct::Result.new(message, nil) },
-        xcode_summary.fetch(:compile_warnings, {}).map { |h| Struct::Result.new(format_compile_warning(h), parse_location(h)) }
+        xcode_summary.fetch(:compile_warnings, {}).map do |h|
+          Struct::Result.new(format_compile_warning(h), parse_location(h))
+        end
       ].flatten.uniq.compact.reject { |result| result.message.nil? }
     end
 
     def errors(xcode_summary)
       [
         xcode_summary[:errors],
-        xcode_summary.fetch(:compile_errors, {}).map { |h| Struct::Result.new(format_compile_warning(h), parse_location(h)) },
-        xcode_summary.fetch(:file_missing_errors, {}).map { |h| Struct::Result.new(format_format_file_missing_error(h), parse_location(h)) },
-        xcode_summary.fetch(:undefined_symbols_errors, {}).map { |h| Struct::Result.new(format_undefined_symbols(h), nil) },
-        xcode_summary.fetch(:duplicate_symbols_errors, {}).map { |h| Struct::Result.new(format_duplicate_symbols(h), nil) },
+        xcode_summary.fetch(:compile_errors, {}).map do |h|
+          Struct::Result.new(format_compile_warning(h), parse_location(h))
+        end,
+        xcode_summary.fetch(:file_missing_errors, {}).map do |h|
+          Struct::Result.new(format_format_file_missing_error(h), parse_location(h))
+        end,
+        xcode_summary.fetch(:undefined_symbols_errors, {}).map do |h|
+          Struct::Result.new(format_undefined_symbols(h), nil)
+        end,
+        xcode_summary.fetch(:duplicate_symbols_errors, {}).map do |h|
+          Struct::Result.new(format_duplicate_symbols(h), nil)
+        end,
         xcode_summary.fetch(:tests_failures, {}).map do |test_suite, failures|
           failures.map do |failure|
             Struct::Result.new(format_test_failure(test_suite, failure), parse_test_location(failure))
           end
-        end.flatten
+        end
       ].flatten.uniq.compact.reject { |result| result.message.nil? }
     end
 
@@ -147,7 +157,7 @@ module Danger
     end
 
     def parse_test_location(failure)
-      path, line = failure[:file_path].split(":")
+      path, line = failure[:file_path].split(':')
       file_name = relative_path(path)
       Struct::Location.new(file_name, path, line)
     end

--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -153,13 +153,14 @@ module Danger
     end
 
     def parse_location(h)
-      Struct::Location.new(h[:file_name], h[:file_path], h[:line])
+      file_path, line, _column = h[:file_path].split(':')
+      Struct::Location.new(h[:file_name], file_path, line.to_i)
     end
 
     def parse_test_location(failure)
       path, line = failure[:file_path].split(':')
       file_name = relative_path(path)
-      Struct::Location.new(file_name, path, line)
+      Struct::Location.new(file_name, path, line.to_i)
     end
 
     def format_path(path)

--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -18,8 +18,8 @@ module Danger
   # @tags xcode, xcodebuild, format
   #
   class DangerXcodeSummary < Plugin
-    Struct.new('Location', :file_name, :file_path, :line)
-    Struct.new('Result', :message, :location)
+    Location = Struct.new(:file_name, :file_path, :line)
+    Result = Struct.new(:message, :location)
 
     # The project root, which will be used to make the paths relative.
     # Defaults to `pwd`.
@@ -120,10 +120,10 @@ module Danger
 
     def warnings(xcode_summary)
       [
-        xcode_summary.fetch(:warnings, []).map { |message| Struct::Result.new(message, nil) },
-        xcode_summary.fetch(:ld_warnings, []).map { |message| Struct::Result.new(message, nil) },
+        xcode_summary.fetch(:warnings, []).map { |message| Result.new(message, nil) },
+        xcode_summary.fetch(:ld_warnings, []).map { |message| Result.new(message, nil) },
         xcode_summary.fetch(:compile_warnings, {}).map do |h|
-          Struct::Result.new(format_compile_warning(h), parse_location(h))
+          Result.new(format_compile_warning(h), parse_location(h))
         end
       ].flatten.uniq.compact.reject { |result| result.message.nil? }
     end
@@ -132,20 +132,20 @@ module Danger
       [
         xcode_summary[:errors],
         xcode_summary.fetch(:compile_errors, {}).map do |h|
-          Struct::Result.new(format_compile_warning(h), parse_location(h))
+          Result.new(format_compile_warning(h), parse_location(h))
         end,
         xcode_summary.fetch(:file_missing_errors, {}).map do |h|
-          Struct::Result.new(format_format_file_missing_error(h), parse_location(h))
+          Result.new(format_format_file_missing_error(h), parse_location(h))
         end,
         xcode_summary.fetch(:undefined_symbols_errors, {}).map do |h|
-          Struct::Result.new(format_undefined_symbols(h), nil)
+          Result.new(format_undefined_symbols(h), nil)
         end,
         xcode_summary.fetch(:duplicate_symbols_errors, {}).map do |h|
-          Struct::Result.new(format_duplicate_symbols(h), nil)
+          Result.new(format_duplicate_symbols(h), nil)
         end,
         xcode_summary.fetch(:tests_failures, {}).map do |test_suite, failures|
           failures.map do |failure|
-            Struct::Result.new(format_test_failure(test_suite, failure), parse_test_location(failure))
+            Result.new(format_test_failure(test_suite, failure), parse_test_location(failure))
           end
         end
       ].flatten.uniq.compact.reject { |result| result.message.nil? }
@@ -153,13 +153,13 @@ module Danger
 
     def parse_location(h)
       file_path, line, _column = h[:file_path].split(':')
-      Struct::Location.new(h[:file_name], file_path, line.to_i)
+      Location.new(h[:file_name], file_path, line.to_i)
     end
 
     def parse_test_location(failure)
       path, line = failure[:file_path].split(':')
       file_name = relative_path(path)
-      Struct::Location.new(file_name, path, line.to_i)
+      Location.new(file_name, path, line.to_i)
     end
 
     def format_path(path)

--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -1,5 +1,4 @@
 require 'json'
-require 'pathname'
 
 module Danger
   # Shows all build errors, warnings and unit tests results generated from `xcodebuild`.

--- a/spec/xcode_summary_spec.rb
+++ b/spec/xcode_summary_spec.rb
@@ -99,7 +99,7 @@ module Danger
             @xcode_summary.inline_mode = true
           end
 
-          it 'formats test errors' do
+          it 'asserts errors on the line' do
             allow(@xcode_summary).to receive(:fail)
             @xcode_summary.report('spec/fixtures/test_errors.json')
             expect(@xcode_summary).to have_received(:fail).with(
@@ -110,7 +110,7 @@ module Danger
             )
           end
 
-          it 'formats compile warnings' do
+          it 'asserts warning on the line' do
             allow(@xcode_summary).to receive(:warn)
             @xcode_summary.report('spec/fixtures/summary.json')
             expect(@xcode_summary).to have_received(:warn).with(

--- a/spec/xcode_summary_spec.rb
+++ b/spec/xcode_summary_spec.rb
@@ -93,6 +93,40 @@ module Danger
             # rubocop:enable LineLength
           ]
         end
+
+        context 'with inline_mode' do
+          before do
+            @xcode_summary.inline_mode = true
+          end
+
+          it 'formats test errors' do
+            allow(@xcode_summary).to receive(:fail)
+            @xcode_summary.report('spec/fixtures/test_errors.json')
+            expect(@xcode_summary).to have_received(:fail).with(
+              instance_of(String),
+              sticky: false,
+              file: 'MyWeight/MyWeightTests/Tests.swift',
+              line: 86
+            )
+          end
+
+          it 'formats compile warnings' do
+            allow(@xcode_summary).to receive(:warn)
+            @xcode_summary.report('spec/fixtures/summary.json')
+            expect(@xcode_summary).to have_received(:warn).with(
+              instance_of(String),
+              sticky: false,
+              file: 'Bla.m',
+              line: 32
+            )
+            expect(@xcode_summary).to have_received(:warn).with(
+              instance_of(String),
+              sticky: false,
+              file: 'ISO8601DateFormatter.m',
+              line: 176
+            )
+          end
+        end
       end
     end
 


### PR DESCRIPTION
I implement `inline_mode`.

```ruby
xcode_summary.inline_mode = true
xcode_summary.report "xcodebuild.json"
```

When this option is enabled, warnings and errors are commented on each lines.
Default value is `false`.

![screen shot 2017-04-25 at 17 30 21](https://cloud.githubusercontent.com/assets/147051/25376029/b7e007de-29dd-11e7-8e20-003ab0a75543.png)
![screen shot 2017-04-25 at 17 34 30](https://cloud.githubusercontent.com/assets/147051/25376031/b9f6d750-29dd-11e7-875d-39cf5da1efe9.png)

This option is inspired by its of [danger-swiftlint](https://github.com/ashfurrow/danger-swiftlint)

Please review 🙏 
