### PR TITLE
Fix parsing issue for errors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 pkg
 .idea/
+.yardoc

--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -130,7 +130,7 @@ module Danger
 
     def errors(xcode_summary)
       [
-        xcode_summary[:errors],
+        xcode_summary.fetch(:errors, []).map { |message| Result.new(message, nil) },
         xcode_summary.fetch(:compile_errors, {}).map do |h|
           Result.new(format_compile_warning(h), parse_location(h))
         end,

--- a/spec/fixtures/errors.json
+++ b/spec/fixtures/errors.json
@@ -1,0 +1,31 @@
+{
+  "warnings": [
+
+  ],
+  "ld_warnings": [
+
+  ],
+  "compile_warnings": [
+
+  ],
+  "errors": [
+    "some error",
+    "another error"
+  ],
+  "compile_errors": [
+
+  ],
+  "file_missing_errors": [
+
+  ],
+  "undefined_symbols_errors": [
+
+  ],
+  "duplicate_symbols_errors": [
+
+  ],
+  "tests_failures": {
+  },
+  "tests_summary_messages": [
+  ]
+}

--- a/spec/xcode_summary_spec.rb
+++ b/spec/xcode_summary_spec.rb
@@ -94,6 +94,14 @@ module Danger
           ]
         end
 
+        it 'formats errors' do
+          @xcode_summary.report('spec/fixtures/errors.json')
+          expect(@dangerfile.status_report[:errors]).to eq [
+            'some error',
+            'another error'
+          ]
+        end
+
         context 'with inline_mode' do
           before do
             @xcode_summary.inline_mode = true


### PR DESCRIPTION
I'm so sorry to cause a bug on #16. 😭 

If build reports have `errors` value, it's failed to parse the reports.
So I fixed this and I added spec and fixture.

Please review 🙏 

```
[!] The exception involves the following plugins:
 -  danger-xcode_summary
bundler: failed to load command: danger (/Users/device/.rbenv/versions/2.3/bin/danger)
Danger::DSLError: [0;31;49m
[!] Invalid `Dangerfile` file: undefined method `message' for #<String:0x007fdc80c016d8>[0m
 #  from Dangerfile:5
 #  -------------------------------------------
 #  xcode_summary.inline_mode = true
 >  xcode_summary.report 'xcodebuild.json'
 #  
 #  -------------------------------------------

  /Users/device/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/danger-xcode_summary-0.2.0/lib/xcode_summary/plugin.rb:151:in `block in errors'
  /Users/device/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/danger-xcode_summary-0.2.0/lib/xcode_summary/plugin.rb:151:in `reject'
  /Users/device/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/danger-xcode_summary-0.2.0/lib/xcode_summary/plugin.rb:151:in `errors'
  /Users/device/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/danger-xcode_summary-0.2.0/lib/xcode_summary/plugin.rb:102:in `format_summary'
  /Users/device/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/danger-xcode_summary-0.2.0/lib/xcode_summary/plugin.rb:85:in `report'
  Dangerfile:5:in `block in parse'
  /Users/device/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/danger-5.2.1/lib/danger/danger_core/dangerfile.rb:199:in `eval'
  /Users/device/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/danger-5.2.1/lib/danger/danger_core/dangerfile.rb:199:in `block in parse'
  /Users/device/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/danger-5.2.1/lib/danger/danger_core/dangerfile.rb:195:in `instance_eval'
  /Users/device/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/danger-5.2.1/lib/danger/danger_core/dangerfile.rb:195:in `parse'
  /Users/device/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/danger-5.2.1/lib/danger/danger_core/dangerfile.rb:272:in `run'
  /Users/device/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/danger-5.2.1/lib/danger/danger_core/executor.rb:27:in `run'
  /Users/device/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/danger-5.2.1/lib/danger/commands/runner.rb:66:in `run'
  /Users/device/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/claide-1.0.1/lib/claide/command.rb:334:in `run'
  /Users/device/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/danger-5.2.1/bin/danger:5:in `<top (required)>'
  /Users/device/.rbenv/versions/2.3/bin/danger:22:in `load'
  /Users/device/.rbenv/versions/2.3/bin/danger:22:in `<top (required)>'
```