### PR TITLE
Add feature to filter the results

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ You can also ignore warnings from certain files by setting `ignored_files`:
 ```ruby
 # Ignoring warnings from Pods
 xcode_summary.ignored_files = '**/Pods/**'
+
+# Ignoring warnings for ld_warnings
+xcode_summary.ignored_categories = %i(ld_warnings)
+
 xcode_summary.report 'xcodebuild.json'
 ```
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ You can also ignore warnings from certain files by setting `ignored_files`:
 xcode_summary.ignored_files = '**/Pods/**'
 
 # Ignoring specific warnings
-xcode_summary.ignored_warnings { |result|
+xcode_summary.ignored_results { |result|
   result.message.start_with 'ld' # Ignore ld_warnings
 }
 

--- a/README.md
+++ b/README.md
@@ -101,8 +101,10 @@ You can also ignore warnings from certain files by setting `ignored_files`:
 # Ignoring warnings from Pods
 xcode_summary.ignored_files = '**/Pods/**'
 
-# Ignoring warnings for ld_warnings
-xcode_summary.ignored_categories = %i(ld_warnings)
+# Ignoring specific warnings
+xcode_summary.ignored_warnings { |result|
+  result.message.start_with 'ld' # Ignore ld_warnings
+}
 
 xcode_summary.report 'xcodebuild.json'
 ```

--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -35,6 +35,15 @@ module Danger
     # @return   [[String]]
     attr_accessor :ignored_files
 
+    # A array of symbols which indicates category name
+    # that you want to ignore warnings on.
+    # Defaults to empty array.
+    # An example would be `%i(ld_warnings)` to ignore warnings for ld_warnings.
+    #
+    # @param    [[Symbol]] value
+    # @return   [[Symbol]]
+    attr_accessor :ignored_categories
+
     # Defines if the test summary will be sticky or not.
     # Defaults to `false`.
     # @param    [Boolean] value
@@ -61,6 +70,10 @@ module Danger
 
     def ignored_files
       [@ignored_files].flatten.compact
+    end
+
+    def ignored_categories
+      @ignored_categories || []
     end
 
     def sticky_summary
@@ -119,6 +132,7 @@ module Danger
     end
 
     def warnings(xcode_summary)
+      xcode_summary = xcode_summary.delete_if { |k, _| ignored_categories.include?(k) }
       [
         xcode_summary.fetch(:warnings, []).map { |message| Result.new(message, nil) },
         xcode_summary.fetch(:ld_warnings, []).map { |message| Result.new(message, nil) },
@@ -129,6 +143,7 @@ module Danger
     end
 
     def errors(xcode_summary)
+      xcode_summary = xcode_summary.delete_if { |k, _| ignored_categories.include?(k) }
       [
         xcode_summary.fetch(:errors, []).map { |message| Result.new(message, nil) },
         xcode_summary.fetch(:compile_errors, {}).map do |h|

--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -35,14 +35,12 @@ module Danger
     # @return   [[String]]
     attr_accessor :ignored_files
 
-    # A array of symbols which indicates category name
-    # that you want to ignore warnings on.
-    # Defaults to empty array.
-    # An example would be `%i(ld_warnings)` to ignore warnings for ld_warnings.
+    # A block that filters specific results.
+    # An example would be `lambda { |result| result.message.start_with?('ld') }` to ignore results for ld_warnings.
     #
     # @param    [Block value
     # @return   [Block]
-    attr_accessor :ignored_warnings
+    attr_accessor :ignored_results
 
     # Defines if the test summary will be sticky or not.
     # Defaults to `false`.
@@ -72,8 +70,8 @@ module Danger
       [@ignored_files].flatten.compact
     end
 
-    def ignored_warnings(&block)
-      @ignored_warnings ||= block
+    def ignored_results(&block)
+      @ignored_results ||= block
     end
 
     def sticky_summary
@@ -139,7 +137,7 @@ module Danger
           Result.new(format_compile_warning(h), parse_location(h))
         end
       ].flatten.uniq.compact.reject { |result| result.message.nil? }
-      warnings.delete_if(&ignored_warnings)
+      warnings.delete_if(&ignored_results)
     end
 
     def errors(xcode_summary)
@@ -163,7 +161,7 @@ module Danger
           end
         end
       ].flatten.uniq.compact.reject { |result| result.message.nil? }
-      errors.delete_if(&ignored_warnings)
+      errors.delete_if(&ignored_results)
     end
 
     def parse_location(h)

--- a/spec/fixtures/ld_warnings.json
+++ b/spec/fixtures/ld_warnings.json
@@ -1,0 +1,31 @@
+{
+  "warnings": [
+
+  ],
+  "ld_warnings": [
+    "some warning",
+    "another warning"
+  ],
+  "compile_warnings": [
+
+  ],
+  "errors": [
+
+  ],
+  "compile_errors": [
+
+  ],
+  "file_missing_errors": [
+
+  ],
+  "undefined_symbols_errors": [
+
+  ],
+  "duplicate_symbols_errors": [
+
+  ],
+  "tests_failures": {
+  },
+  "tests_summary_messages": [
+  ]
+}

--- a/spec/xcode_summary_spec.rb
+++ b/spec/xcode_summary_spec.rb
@@ -136,17 +136,19 @@ module Danger
           end
         end
 
-        context 'with ignored_categories' do
-          before { @xcode_summary.ignored_categories = %i[errors ld_warnings] }
+        context 'with ignored_warnings' do
+          before do
+            @xcode_summary.ignored_warnings { |result| result.message.start_with? 'some' }
+          end
 
           it 'asserts no errors' do
             @xcode_summary.report('spec/fixtures/errors.json')
-            expect(@dangerfile.status_report[:errors]).to be_empty
+            expect(@dangerfile.status_report[:errors]).to eq ['another error']
           end
 
           it 'asserts no warnings' do
             @xcode_summary.report('spec/fixtures/ld_warnings.json')
-            expect(@dangerfile.status_report[:warnings]).to be_empty
+            expect(@dangerfile.status_report[:warnings]).to eq ['another warning']
           end
         end
       end

--- a/spec/xcode_summary_spec.rb
+++ b/spec/xcode_summary_spec.rb
@@ -136,9 +136,9 @@ module Danger
           end
         end
 
-        context 'with ignored_warnings' do
+        context 'with ignored_results' do
           before do
-            @xcode_summary.ignored_warnings { |result| result.message.start_with? 'some' }
+            @xcode_summary.ignored_results { |result| result.message.start_with? 'some' }
           end
 
           it 'asserts no errors' do

--- a/spec/xcode_summary_spec.rb
+++ b/spec/xcode_summary_spec.rb
@@ -135,6 +135,20 @@ module Danger
             )
           end
         end
+
+        context 'with ignored_categories' do
+          before { @xcode_summary.ignored_categories = %i[errors ld_warnings] }
+
+          it 'asserts no errors' do
+            @xcode_summary.report('spec/fixtures/errors.json')
+            expect(@dangerfile.status_report[:errors]).to be_empty
+          end
+
+          it 'asserts no warnings' do
+            @xcode_summary.report('spec/fixtures/ld_warnings.json')
+            expect(@dangerfile.status_report[:warnings]).to be_empty
+          end
+        end
       end
     end
 


### PR DESCRIPTION
## Motivation

I want to ignore warnings for `ld_warnings`. Some warnings can't be resolved.

![20170529080054_img20170529-18-11pr22u](https://cloud.githubusercontent.com/assets/147051/26545715/acbe976a-44a1-11e7-934f-0b939501eb0f.png)


## Description

I introduced the new parameter `ignored_errors`.
This value is set, then warnings/errors are filtered by this block.

```ruby
xcode_summary.ignored_results do |result|
  result.message.start_with? 'ld'
end
```

How about this feature?