### PR TITLE
Added switch for warnings as errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ xcode_summary.inline_mode = true
 xcode_summary.report 'xcodebuild.json'
 ```
 
+You can treat warnings as errors with `warnings_as_errors`.
+```ruby
+xcode_summary.warnings_as_errors = true
+xcode_summary.report 'xcodebuild.json'
+```
+
 ## License
 
 danger-xcode_summary is released under the MIT license. See [LICENSE.txt](LICENSE.txt) for details.

--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -60,6 +60,12 @@ module Danger
     # @return   [Boolean]
     attr_accessor :inline_mode
 
+    # Defines if warnings should be shown as errors.
+    # Defaults to `false`.
+    # @param    [Boolean] value
+    # @return   [Boolean]
+    attr_accessor :warnings_as_errors
+
     def project_root
       root = @project_root || Dir.pwd
       root += '/' unless root.end_with? '/'
@@ -86,6 +92,10 @@ module Danger
       @inline_mode || false
     end
 
+    def warnings_as_errors
+        @warnings_as_errors || false
+    end
+
     # Reads a file with JSON Xcode summary and reports it.
     #
     # @param    [String] file_path Path for Xcode summary in JSON format.
@@ -105,9 +115,17 @@ module Danger
       messages(xcode_summary).each { |s| message(s, sticky: sticky_summary) }
       warnings(xcode_summary).each do |result|
         if inline_mode && result.location
-          warn(result.message, sticky: false, file: result.location.file_name, line: result.location.line)
+          if warnings_as_errors
+            fail(result.message, sticky: false, file: result.location.file_name, line: result.location.line)
+          else
+            warn(result.message, sticky: false, file: result.location.file_name, line: result.location.line)
+          end
         else
-          warn(result.message, sticky: false)
+          if warnings_as_errors
+            fail(result.message, sticky: false)
+          else
+            warn(result.message, sticky: false)
+          end
         end
       end
       errors(xcode_summary).each do |result|

--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -93,7 +93,7 @@ module Danger
     end
 
     def warnings_as_errors
-        @warnings_as_errors || false
+      @warnings_as_errors || false
     end
 
     # Reads a file with JSON Xcode summary and reports it.

--- a/spec/xcode_summary_spec.rb
+++ b/spec/xcode_summary_spec.rb
@@ -25,6 +25,10 @@ module Danger
         expect(@xcode_summary.test_summary).to eq true
       end
 
+      it 'sets warnings_as_errors to false as default' do
+        expect(@xcode_summary.warnings_as_errors).to eq false
+      end
+
       it 'fail if file does not exist' do
         @xcode_summary.report('spec/fixtures/inexistent_file.json')
         expect(@dangerfile.status_report[:errors]).to eq ['summary file not found']


### PR DESCRIPTION
This can be handy if you want to be really strict about code warnings.