### PR TITLE
add method to return warning and error count

### DIFF
--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -103,12 +103,12 @@ module Danger
     #
     # @param    [String] file_path Path for Xcode summary in JSON format.
     # @return   [String] JSON string with warningCount and errorCount
-    def warningErrorCount(file_path)
+    def warning_error_count(file_path)
       if File.file?(file_path)
         xcode_summary = JSON.parse(File.read(file_path), symbolize_names: true)
-        warningCount = warnings(xcode_summary).count
-        errorCount = errors(xcode_summary).count
-        result = {:warningCount => warningCount, :errorCount => errorCount}
+        warning_count = warnings(xcode_summary).count
+        error_count = errors(xcode_summary).count
+        result = { warnings: warning_count, errors: error_count }
         result.to_json
       else
         fail 'summary file not found'

--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -99,6 +99,22 @@ module Danger
       end
     end
 
+    # Reads a file with JSON Xcode summary and reports its warning and error count.
+    #
+    # @param    [String] file_path Path for Xcode summary in JSON format.
+    # @return   [String] JSON string with warningCount and errorCount
+    def warningErrorCount(file_path)
+      if File.file?(file_path)
+        xcode_summary = JSON.parse(File.read(file_path), symbolize_names: true)
+        warningCount = warnings(xcode_summary).count
+        errorCount = errors(xcode_summary).count
+        result = {:warningCount => warningCount, :errorCount => errorCount}
+        result.to_json
+      else
+        fail 'summary file not found'
+      end
+    end
+
     private
 
     def format_summary(xcode_summary)

--- a/spec/xcode_summary_spec.rb
+++ b/spec/xcode_summary_spec.rb
@@ -103,8 +103,8 @@ module Danger
         end
 
         it 'report waring and error counts' do
-          result = @xcode_summary.warningErrorCount('spec/fixtures/summary.json')
-          expect(result).to eq "{\"warningCount\":2,\"errorCount\":0}"
+          result = @xcode_summary.warning_error_count('spec/fixtures/summary.json')
+          expect(result).to eq '{"warnings":2,"errors":0}'
         end
 
         context 'with inline_mode' do
@@ -157,13 +157,13 @@ module Danger
           end
 
           it 'report waring and error counts with no errors' do
-            result = @xcode_summary.warningErrorCount('spec/fixtures/errors.json')
-            expect(result).to eq "{\"warningCount\":0,\"errorCount\":1}"
+            result = @xcode_summary.warning_error_count('spec/fixtures/errors.json')
+            expect(result).to eq '{"warnings":0,"errors":1}'
           end
 
           it 'report waring and error counts with no warnings' do
-            result = @xcode_summary.warningErrorCount('spec/fixtures/ld_warnings.json')
-            expect(result).to eq "{\"warningCount\":1,\"errorCount\":0}"
+            result = @xcode_summary.warning_error_count('spec/fixtures/ld_warnings.json')
+            expect(result).to eq '{"warnings":1,"errors":0}'
           end
         end
       end

--- a/spec/xcode_summary_spec.rb
+++ b/spec/xcode_summary_spec.rb
@@ -102,6 +102,11 @@ module Danger
           ]
         end
 
+        it 'report waring and error counts' do
+          result = @xcode_summary.warningErrorCount('spec/fixtures/summary.json')
+          expect(result).to eq "{\"warningCount\":2,\"errorCount\":0}"
+        end
+
         context 'with inline_mode' do
           before do
             @xcode_summary.inline_mode = true
@@ -149,6 +154,16 @@ module Danger
           it 'asserts no warnings' do
             @xcode_summary.report('spec/fixtures/ld_warnings.json')
             expect(@dangerfile.status_report[:warnings]).to eq ['another warning']
+          end
+
+          it 'report waring and error counts with no errors' do
+            result = @xcode_summary.warningErrorCount('spec/fixtures/errors.json')
+            expect(result).to eq "{\"warningCount\":0,\"errorCount\":1}"
+          end
+
+          it 'report waring and error counts with no warnings' do
+            result = @xcode_summary.warningErrorCount('spec/fixtures/ld_warnings.json')
+            expect(result).to eq "{\"warningCount\":1,\"errorCount\":0}"
           end
         end
       end


### PR DESCRIPTION
In danger test we would like to know the warning and error count from xcode summary. Add this method to return warning and error count.