### PR TITLE
Guard against case where no plugins are available to html format link

### DIFF
--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -216,7 +216,11 @@ module Danger
       plugins = Plugin.all_plugins.select { |plugin| Dangerfile.essential_plugin_classes.include? plugin }
       plugin = plugins.select { |p| p.method_defined? :html_link }.map { |p| p.new(@dangerfile) }.compact.first
 
-      plugin.html_link(path)
+      if plugin
+        plugin.html_link(path)
+      else
+        clean_path
+      end
     end
 
     def parse_filename(path)

--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -208,18 +208,17 @@ module Danger
     end
 
     def format_path(path)
-      clean_path, line = parse_filename(path)
-      path = clean_path + '#L' + line if clean_path && line
-
       # Pick a Dangerfile plugin for a chosen request_source
       # based on https://github.com/danger/danger/blob/master/lib/danger/plugin_support/plugin.rb#L31
       plugins = Plugin.all_plugins.select { |plugin| Dangerfile.essential_plugin_classes.include? plugin }
       plugin = plugins.select { |p| p.method_defined? :html_link }.map { |p| p.new(@dangerfile) }.compact.first
 
       if plugin
+        clean_path, line = parse_filename(path)
+        path = clean_path + '#L' + line if clean_path && line
         plugin.html_link(path)
       else
-        clean_path
+        path
       end
     end
 


### PR DESCRIPTION
Addresses issue #40, caused by some git hosts not implementing the `html_link` method. In the case where no plugins are available which support this functionality, the path is formatted without HTML. 