### PR TITLE
Fix Inline Comments

### DIFF
--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -200,7 +200,8 @@ module Danger
 
     def parse_location(input)
       file_path, line, _column = input[:file_path].split(':')
-      Location.new(input[:file_name], file_path, line.to_i)
+      file_name = relative_path(file_path)
+      Location.new(file_name, file_path, line.to_i)
     end
 
     def parse_test_location(failure)

--- a/spec/xcode_summary_spec.rb
+++ b/spec/xcode_summary_spec.rb
@@ -131,13 +131,13 @@ module Danger
             expect(@xcode_summary).to have_received(:warn).with(
               instance_of(String),
               sticky: false,
-              file: 'Bla.m',
+              file: 'MyWeight/Bla.m',
               line: 32
             )
             expect(@xcode_summary).to have_received(:warn).with(
               instance_of(String),
               sticky: false,
-              file: 'ISO8601DateFormatter.m',
+              file: 'MyWeight/Pods/ISO8601DateFormatter/ISO8601DateFormatter.m',
               line: 176
             )
           end


### PR DESCRIPTION
I changed the value passed for the `file` attribute in the `warn()` method to be the _relative file path_ instead of just the _filename_. It is not very well documented by danger, but after some testing I figured out, that for the inline comments feature to work, the _relative file path_ has to be passed to `warn()` to properly comment inline.
I also adapted the tests, to test for the relative path now instead of just the file name.

This should solve #49