### PR TITLE
Fix a bug that was causing a huge amount of calls to git APIs

### DIFF
--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -98,6 +98,13 @@ module Danger
     def ignores_warnings
       @ignores_warnings || false
     end
+    
+    def plugin
+      # Pick a Dangerfile plugin for a chosen request_source
+      # based on https://github.com/danger/danger/blob/master/lib/danger/plugin_support/plugin.rb#L31
+      plugins = Plugin.all_plugins.select { |plugin| Dangerfile.essential_plugin_classes.include? plugin }
+      @plugin ||= plugins.select { |p| p.method_defined? :html_link }.map { |p| p.new(@dangerfile) }.compact.first
+    end
     # rubocop:enable Lint/DuplicateMethods
 
     # Reads a file with JSON Xcode summary and reports it.
@@ -210,11 +217,6 @@ module Danger
     end
 
     def format_path(path)
-      # Pick a Dangerfile plugin for a chosen request_source
-      # based on https://github.com/danger/danger/blob/master/lib/danger/plugin_support/plugin.rb#L31
-      plugins = Plugin.all_plugins.select { |plugin| Dangerfile.essential_plugin_classes.include? plugin }
-      plugin = plugins.select { |p| p.method_defined? :html_link }.map { |p| p.new(@dangerfile) }.compact.first
-
       if plugin
         clean_path, line = parse_filename(path)
         path = clean_path + '#L' + line if clean_path && line


### PR DESCRIPTION
`format_path` is called for each warning/error discovered, and that the method is creating a new instance of the git source plugin at each invocation.
This prevent the plugin from caching any data and, in the case of gitlab at least, means we're hitting the API repeatedly for each warning just to grab the project base URL.
In my case this meant 1000+ calls to the GitLab API which caused a large delay.

This change caches the git plugin on an instance variable so that we don't need to create it every time.