### PR TITLE
Check that there's value in StartingLineNumber

### DIFF
--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -185,7 +185,8 @@ module Danger
       file_name = file_path.split('/').last
       fragment = document_location.url.split('#').last
       params = CGI.parse(fragment).transform_values(&:first)
-      line = params['StartingLineNumber'].to_i + 1 # StartingLineNumber is 0-based, but we need a 1-based value
+      number = params['StartingLineNumber']
+      line = number.empty? ? 0 : number.to_i + 1 # StartingLineNumber is 0-based, but we need a 1-based value
       Location.new(file_name, relative_path(file_path), line)
     end
 


### PR DESCRIPTION
Avoids crashing the whole danger run, if the value is not present.

E.g. when a test crashes it may produce the following message:

> Crash: xctest (39936) -[Foo foo]: Namespace SIGNAL, Code 0x4. CoreSimulator 776.4 - Device: iPhone SE (1st generation) (577AEB93-CFCD-498E-BA90-A67D0463FB58) - Runtime: iOS 13.5 (17F61) - DeviceType: iPhone SE (1st generation)
> Fatal error: Array index out of range: file /Library/Caches/com.apple.xbs/Sources/swiftlang/swiftlang-1103.2.25.8/swift/stdlib/public/core/ContiguousArrayBuffer.swift, line 122
> 

Now this test crashes because of out of range array access and it's an issue in the test, but danger should still be able to run and report the error in the PR.

Feel free to modify things if there's a better way to handle this.
