### PR TITLE
Strictness of Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ xcode_summary.inline_mode = true
 xcode_summary.report 'MyApp.xcresult'
 ```
 
+You can use `strict` to reporting errors as warnings thereby don't block merge PR.
+
+ ```ruby
+ # If value is `false`, then errors will be reporting as warnings
+ xcode_summary.strict = false
+ ```
+
 You can get warning and error number by calling `warning_error_count`. The return will be a JSON string contains warning and error count, e.g `{"warnings":1,"errors":3}`:
 
 ```ruby

--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -55,7 +55,7 @@ module Danger
     # @return   [Boolean]
     attr_accessor :ignores_warnings
 
-    # Defines errors strict. If value is `false`, then errors will be treat as warnings.
+    # Defines errors strict. If value is `false`, then errors will be reporting as warnings.
     # Defaults to `true`
     attr_accessor :strict
 

--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -56,7 +56,7 @@ module Danger
     attr_accessor :ignores_warnings
 
     # Defines errors strict. If value is `false`, then errors will be treat as warnings.
-    # Defaults to `false`
+    # Defaults to `true`
     attr_accessor :strict
 
     # rubocop:disable Lint/DuplicateMethods

--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -57,6 +57,8 @@ module Danger
 
     # Defines errors strict. If value is `false`, then errors will be reporting as warnings.
     # Defaults to `true`
+    # @param    [Boolean] value
+    # @return   [Boolean]
     attr_accessor :strict
 
     # rubocop:disable Lint/DuplicateMethods
@@ -138,7 +140,6 @@ module Danger
             warn(result.message, sticky: false)
           end
         end
-        # rubocop:disable Lint/UnreachableLoop
         errors(action).each do |result|
           if inline_mode && result.location
             if strict
@@ -154,7 +155,6 @@ module Danger
             end
           end
         end
-        # rubocop:enable Lint/UnreachableLoop
       end
     end
 

--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -55,6 +55,10 @@ module Danger
     # @return   [Boolean]
     attr_accessor :ignores_warnings
 
+    # Defines errors strict. If value is `false`, then errors will be treat as warnings.
+    # Defaults to `false`
+    attr_accessor :strict
+
     # rubocop:disable Lint/DuplicateMethods
     def project_root
       root = @project_root || Dir.pwd
@@ -76,6 +80,10 @@ module Danger
 
     def ignores_warnings
       @ignores_warnings || false
+    end
+
+    def strict
+      @strict.nil? ? true : @strict
     end
 
     # Pick a Dangerfile plugin for a chosen request_source and cache it
@@ -133,9 +141,17 @@ module Danger
         # rubocop:disable Lint/UnreachableLoop
         errors(action).each do |result|
           if inline_mode && result.location
-            fail(result.message, sticky: false, file: result.location.file_path, line: result.location.line)
+            if strict
+              fail(result.message, sticky: false, file: result.location.file_path, line: result.location.line)
+            else
+              warn(result.message, sticky: false, file: result.location.file_path, line: result.location.line)
+            end
           else
-            fail(result.message, sticky: false)
+            if strict
+              fail(result.message, sticky: false)
+            else
+              warn(result.message, sticky: false)
+            end
           end
         end
         # rubocop:enable Lint/UnreachableLoop

--- a/spec/xcode_summary_spec.rb
+++ b/spec/xcode_summary_spec.rb
@@ -172,6 +172,22 @@ module Danger
             expect(result).to eq '{"warnings":19,"errors":1}'
           end
         end
+
+        context 'without strict' do
+          defore do
+            @xcode_summary.strict = false
+          end
+
+          it 'shows errors as warnings' do
+            @xcode_summary.report('spec/fixtures/build_error.xcresult')
+            expect(@dangerfile.status_report[:warnings]).to_not eq 0
+            expect(@dangerfile.status_report[:errors].count).to eq []
+          end
+
+          it 'report warning and error counts' do
+            result = @xcode_summary.warning_error_count('spec/fixtures/build_error.xcresult')
+            expect(result).to eq '{"warnings":21,"errors":3}'
+          end
       end
     end
 

--- a/spec/xcode_summary_spec.rb
+++ b/spec/xcode_summary_spec.rb
@@ -174,14 +174,14 @@ module Danger
         end
 
         context 'without strict' do
-          defore do
+          before do
             @xcode_summary.strict = false
           end
 
           it 'shows errors as warnings' do
             @xcode_summary.report('spec/fixtures/build_error.xcresult')
-            expect(@dangerfile.status_report[:warnings]).to_not eq 0
-            expect(@dangerfile.status_report[:errors].count).to eq []
+            expect(@dangerfile.status_report[:warnings].count).to_not eq 0
+            expect(@dangerfile.status_report[:errors]).to eq []
           end
 
           it 'report warning and error counts' do

--- a/spec/xcode_summary_spec.rb
+++ b/spec/xcode_summary_spec.rb
@@ -188,6 +188,7 @@ module Danger
             result = @xcode_summary.warning_error_count('spec/fixtures/build_error.xcresult')
             expect(result).to eq '{"warnings":21,"errors":3}'
           end
+        end
       end
     end
 


### PR DESCRIPTION
### Description 📝

Added new flag `strict`, which affect errors reporting. If `strict` is `false`, then **errors** will be reporting as **warnings**, thereby don't block merge PR.

Default value is `true`

```ruby
# Defines errors strict. If value is `false`, then errors will be reporting as warnings.
# Defaults to `true`
attr_accessor :strict
```

Usage:
```ruby
xcode_summary.strict = false
```