### PR TITLE
Ignore test_failures if the overall status is 'succeeded'

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-xcode_summary (1.2.0)
+    danger-xcode_summary (1.2.1)
       danger-plugin-api (~> 1.0)
       xcresult (~> 0.2)
 

--- a/lib/xcode_summary/gem_version.rb
+++ b/lib/xcode_summary/gem_version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module XcodeSummary
-  VERSION = '1.2.0'
+  VERSION = '1.2.1'
 end

--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -183,16 +183,20 @@ module Danger
         Result.new(format_warning(result), result.location)
       end
 
-      test_failures = [
-        action.action_result.issues.test_failure_summaries,
-        action.build_result.issues.test_failure_summaries
-      ].flatten.compact.map do |summary|
-        result = Result.new(summary.message, parse_location(summary.document_location_in_creating_workspace))
-        Result.new(format_test_failure(result, summary.producing_target, summary.test_case_name),
+      if action.action_result.status != 'succeeded' then
+        test_failures = [
+          action.action_result.issues.test_failure_summaries,
+          action.build_result.issues.test_failure_summaries
+        ].flatten.compact.map do |summary|
+          result = Result.new(summary.message, parse_location(summary.document_location_in_creating_workspace))
+          Result.new(format_test_failure(result, summary.producing_target, summary.test_case_name),
                    result.location)
+        end
+        results = (errors + test_failures).uniq.reject { |result| result.message.nil? }
+      else
+        results = (errors).uniq.reject { |result| result.message.nil? }
       end
 
-      results = (errors + test_failures).uniq.reject { |result| result.message.nil? }
       results.delete_if(&ignored_results)
     end
 


### PR DESCRIPTION
Addresses https://github.com/diogot/danger-xcode_summary/issues/73

Only parse test_failures if the overall status is not 'succeeded'.  This ensures that tests that pass via test repetition do not show up as a false negative.