### PR TITLE
Provide `sort_warnings_by` attribute to sort warnings

### DIFF
--- a/spec/xcode_summary_spec.rb
+++ b/spec/xcode_summary_spec.rb
@@ -209,6 +209,54 @@ module Danger
             expect(result).to eq '{"warnings":21,"errors":3}'
           end
         end
+
+        context 'with sort_warnings_by' do
+          before do
+            @xcode_summary.sort_warnings_by do |warning|
+              warning.message.include?('TODOs') ? 0 : 1
+            end
+          end
+          it 'sorts compile warnings' do
+            @xcode_summary.report('spec/fixtures/swiftlint.xcresult')
+            expect(@dangerfile.status_report[:warnings]).to eq [
+              "**<a href='https://github.com/realm/SwiftLint/blob/f211694e7def13785ff62047386437534541d7b3/Carthage/Checkouts/Yams/Sources/Yams/Constructor.swift#L492'>Carthage/Checkouts/Yams/Sources/Yams/Constructor.swift#L492</a>**: Todo Violation: TODOs should be resolved (Should raise error if subnode ...). (todo)",
+              "**<a href='https://github.com/realm/SwiftLint/blob/f211694e7def13785ff62047386437534541d7b3/Carthage/Checkouts/Yams/Tests/YamsTests/SpecTests.swift#L379'>Carthage/Checkouts/Yams/Tests/YamsTests/SpecTests.swift#L379</a>**: Todo Violation: TODOs should be resolved (YAML supports keys other than ...). (todo)",
+              "**<a href='https://github.com/realm/SwiftLint/blob/f211694e7def13785ff62047386437534541d7b3/Carthage/Checkouts/Yams/Tests/YamsTests/SpecTests.swift#L714'>Carthage/Checkouts/Yams/Tests/YamsTests/SpecTests.swift#L714</a>**: Todo Violation: TODOs should be resolved (local tag parsing). (todo)",
+              "**<a href='https://github.com/realm/SwiftLint/blob/f211694e7def13785ff62047386437534541d7b3/Carthage/Checkouts/Yams/Sources/Yams/Representer.swift#L187'>Carthage/Checkouts/Yams/Sources/Yams/Representer.swift#L187</a>**: Todo Violation: TODOs should be resolved (Support `Float80`). (todo)",
+              "**<a href='https://github.com/realm/SwiftLint/blob/f211694e7def13785ff62047386437534541d7b3/Carthage/Checkouts/Yams/Sources/Yams/Constructor.swift#L405'>Carthage/Checkouts/Yams/Sources/Yams/Constructor.swift#L405</a>**: Todo Violation: TODOs should be resolved (YAML supports keys other than ...). (todo)",
+              "**<a href='https://github.com/realm/SwiftLint/blob/f211694e7def13785ff62047386437534541d7b3/Carthage/Checkouts/Yams/Sources/Yams/Constructor.swift#L430'>Carthage/Checkouts/Yams/Sources/Yams/Constructor.swift#L430</a>**: Todo Violation: TODOs should be resolved (Should raise error on other th...). (todo)",
+              "**<a href='https://github.com/realm/SwiftLint/blob/f211694e7def13785ff62047386437534541d7b3/Carthage/Checkouts/Yams/Sources/Yams/Constructor.swift#L450'>Carthage/Checkouts/Yams/Sources/Yams/Constructor.swift#L450</a>**: Todo Violation: TODOs should be resolved (YAML supports Hashable element...). (todo)",
+              "**<a href='https://github.com/realm/SwiftLint/blob/f211694e7def13785ff62047386437534541d7b3/Carthage/Checkouts/Yams/Sources/Yams/Constructor.swift#L478'>Carthage/Checkouts/Yams/Sources/Yams/Constructor.swift#L478</a>**: Todo Violation: TODOs should be resolved (Should raise error if subnode ...). (todo)",
+              "**<a href='https://github.com/realm/SwiftLint/blob/f211694e7def13785ff62047386437534541d7b3/Carthage/Checkouts/Yams/Sources/Yams/Emitter.swift#L340'>Carthage/Checkouts/Yams/Sources/Yams/Emitter.swift#L340</a>**: Todo Violation: TODOs should be resolved (Support tags). (todo)",
+              "**<a href='https://github.com/realm/SwiftLint/blob/f211694e7def13785ff62047386437534541d7b3/Carthage/Checkouts/SWXMLHash/Source/XMLIndexer+XMLIndexerDeserializable.swift#L538'>Carthage/Checkouts/SWXMLHash/Source/XMLIndexer+XMLIndexerDeserializable.swift#L538</a>**: 'public' modifier is redundant for instance method declared in a public extension",
+              "**<a href='https://github.com/realm/SwiftLint/blob/f211694e7def13785ff62047386437534541d7b3/Carthage/Checkouts/SWXMLHash/Source/XMLIndexer+XMLIndexerDeserializable.swift#L552'>Carthage/Checkouts/SWXMLHash/Source/XMLIndexer+XMLIndexerDeserializable.swift#L552</a>**: 'public' modifier is redundant for instance method declared in a public extension",
+              "**<a href='https://github.com/realm/SwiftLint/blob/f211694e7def13785ff62047386437534541d7b3/Carthage/Checkouts/Yams/Sources/Yams/Tag.swift#L88'>Carthage/Checkouts/Yams/Sources/Yams/Tag.swift#L88</a>**: Legacy Hashing Violation: Prefer using the `hash(into:)` function instead of overriding `hashValue` (legacy_hashing)",
+              "**<a href='https://github.com/realm/SwiftLint/blob/f211694e7def13785ff62047386437534541d7b3/Carthage/Checkouts/Result/Result/NoError.swift#L8'>Carthage/Checkouts/Result/Result/NoError.swift#L8</a>**: Will never be executed",
+              "**<a href='https://github.com/realm/SwiftLint/blob/f211694e7def13785ff62047386437534541d7b3/Carthage/Checkouts/Yams/Sources/Yams/Tag.swift#L109'>Carthage/Checkouts/Yams/Sources/Yams/Tag.swift#L109</a>**: Legacy Hashing Violation: Prefer using the `hash(into:)` function instead of overriding `hashValue` (legacy_hashing)",
+              "**<a href='https://github.com/realm/SwiftLint/blob/f211694e7def13785ff62047386437534541d7b3/Carthage/Checkouts/Yams/Sources/Yams/Decoder.swift#L102'>Carthage/Checkouts/Yams/Sources/Yams/Decoder.swift#L102</a>**: Colon Violation: Colons should be next to the identifier when specifying a type and next to the key in dictionary literals. (colon)",
+              "**<a href='https://github.com/realm/SwiftLint/blob/f211694e7def13785ff62047386437534541d7b3/Carthage/Checkouts/Yams/Sources/Yams/Node.swift#L191'>Carthage/Checkouts/Yams/Sources/Yams/Node.swift#L191</a>**: Legacy Hashing Violation: Prefer using the `hash(into:)` function instead of overriding `hashValue` (legacy_hashing)",
+              "**<a href='https://github.com/realm/SwiftLint/blob/f211694e7def13785ff62047386437534541d7b3/Carthage/Checkouts/Yams/Sources/Yams/Encoder.swift#L139'>Carthage/Checkouts/Yams/Sources/Yams/Encoder.swift#L139</a>**: Colon Violation: Colons should be next to the identifier when specifying a type and next to the key in dictionary literals. (colon)",
+              "**<a href='https://github.com/realm/SwiftLint/blob/f211694e7def13785ff62047386437534541d7b3/Carthage/Checkouts/Yams/Sources/Yams/Parser.swift#L441'>Carthage/Checkouts/Yams/Sources/Yams/Parser.swift#L441</a>**: File Line Length Violation: File should contain 400 lines or less: currently contains 441 (file_length)",
+              "**<a href='https://github.com/realm/SwiftLint/blob/f211694e7def13785ff62047386437534541d7b3/Carthage/Checkouts/Yams/Tests/YamsTests/EncoderTests.swift#L924'>Carthage/Checkouts/Yams/Tests/YamsTests/EncoderTests.swift#L924</a>**: Colon Violation: Colons should be next to the identifier when specifying a type and next to the key in dictionary literals. (colon)",
+              "**<a href='https://github.com/realm/SwiftLint/blob/f211694e7def13785ff62047386437534541d7b3/Carthage/Checkouts/Yams/Tests/YamsTests/EncoderTests.swift#L937'>Carthage/Checkouts/Yams/Tests/YamsTests/EncoderTests.swift#L937</a>**: Colon Violation: Colons should be next to the identifier when specifying a type and next to the key in dictionary literals. (colon)",
+              "**<a href='https://github.com/realm/SwiftLint/blob/f211694e7def13785ff62047386437534541d7b3/Carthage/Checkouts/Yams/Tests/YamsTests/EncoderTests.swift#L253'>Carthage/Checkouts/Yams/Tests/YamsTests/EncoderTests.swift#L253</a>**: Superfluous Disable Command Violation: 'unused_private_declaration' is not a valid SwiftLint rule. Please remove it from the disable command. (superfluous_disable_command)"
+            ]
+          end
+
+          it 'formats errors' do
+            @xcode_summary.report('spec/fixtures/build_error.xcresult')
+            expect(@dangerfile.status_report[:errors]).to eq [
+              'Testing cancelled because the build failed.',
+              "**<a href='https://github.com/realm/SwiftLint/blob/f211694e7def13785ff62047386437534541d7b3/Source/SwiftLintFramework/Extensions/QueuedPrint.swift#L13'>Source/SwiftLintFramework/Extensions/QueuedPrint.swift#L13</a>**: Use of unresolved identifier 'queue'",
+              "**<a href='https://github.com/realm/SwiftLint/blob/f211694e7def13785ff62047386437534541d7b3/Source/SwiftLintFramework/Extensions/QueuedPrint.swift#L17'>Source/SwiftLintFramework/Extensions/QueuedPrint.swift#L17</a>**: Use of unresolved identifier 'queue'"
+            ]
+          end
+
+          it 'report warning and error counts' do
+            result = @xcode_summary.warning_error_count('spec/fixtures/build_error.xcresult')
+            expect(result).to eq '{"warnings":21,"errors":3}'
+          end
+        end
       end
     end
 


### PR DESCRIPTION
### Problem
In our code base we keep on deprecating the APIs and because of that the warning result is huge. And with GitHub's max issue comment size we can't see all the warnings and it's hard to find non deprecated warnings in the code with that huge list of warnings. Thus we miss important warning because of deprecated ones.  

### Solution
Provide a `sort_warnings_by` block that sorts the warnings, and with the help of this we can keep important warnings on top and less important warnings at the bottom