### PR TITLE
Check specifically for file url in document_location, fixing crash in Xcode 15 when running in Apple Silicon

### DIFF
--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -245,6 +245,8 @@ module Danger
     end
 
     def format_test_failure(result, producing_target, test_case_name)
+      return escape_reason(result.message) if result.location.nil?
+      
       path = result.location.file_path
       path_link = format_path(path, result.location.line)
       suite_name = "#{producing_target}.#{test_case_name}"

--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -197,7 +197,7 @@ module Danger
     end
 
     def parse_location(document_location)
-      return nil if document_location.nil?
+      return nil if document_location&.url.nil?
 
       file_path = document_location.url.gsub('file://', '').split('#').first
       file_name = file_path.split('/').last


### PR DESCRIPTION
## Problem 
The plugin is breaking with Xcode 15 on certain projects due to a missing url property.

## Error

```
/Users/distiller/project/.bundle/ruby/3.1.0/gems/danger-xcode_summary-1.2.0/lib/xcode_summary/plugin.rb:202:in `parse_location': \e[31m (Danger::DSLError)
[00:05:08]: ▸ [!] Invalid `BuildDangerfile` file: undefined method `gsub' for nil:NilClass
[00:05:08]: ▸ file_path = document_location.url.gsub('file://', '').split('#').first
[00:05:08]: ▸ ^^^^^\e[0m
```
## Description

I've taken inspiration from the recent [fastlane fix addressing the same issue for the trainer.](https://github.com/fastlane/fastlane/pull/21493) 

> It would appear that with Xcode 15 there are at least some cases where test failure data would not include a url property. Adjusting the check in failure_message to specifically verify the presence of self.document_location_in_creating_workspace&.url prior to attempting to append it to the failure message seems liek the most straightforward resolution.



