### PR TITLE
Check if document_location.url is missing

### DIFF
--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -197,7 +197,7 @@ module Danger
     end
 
     def parse_location(document_location)
-      return nil if document_location.nil?
+      return nil if document_location&.url.nil?
 
       file_path = document_location.url.gsub('file://', '').split('#').first
       file_name = file_path.split('/').last


### PR DESCRIPTION
Sometimes, `document_location.url` would be `nil`. It causes runtime error.

```
[!] Invalid Dangerfile file: undefined method gsub for nil:NilClass

  file_path = document_location.url.gsub(`file://`, ``).split(`#`).first
```

This PR avoids calling the `url` property of `nil.`