### PR TITLE
Update xcresult - make it run on Xcode 16

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# TP is the owner. This is a temporary fork.
+*    @getyourguide/tp

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,4 @@ gemspec
 gem 'danger'
 gem 'rubocop'
 gem 'yard'
+gem 'rexml', '3.3.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,8 @@ GEM
       ffi (~> 1.0)
     rchardet (1.8.0)
     regexp_parser (2.9.0)
-    rexml (3.2.6)
+    rexml (3.3.6)
+      strscan
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -134,6 +135,7 @@ GEM
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
     shellany (0.0.1)
+    strscan (3.1.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.3.0)
@@ -154,6 +156,7 @@ DEPENDENCIES
   listen (~> 3.0)
   pry
   rake (~> 13.0)
+  rexml (= 3.3.6)
   rspec (~> 3.4)
   rubocop
   yard

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     danger-xcode_summary (1.3.0)
       danger-plugin-api (~> 1.0)
-      xcresult (~> 0.2)
+      xcresult (~> 0.2.2)
 
 GEM
   remote: https://rubygems.org/
@@ -139,7 +139,7 @@ GEM
     thor (1.3.0)
     unicode-display_width (2.5.0)
     uri (0.13.0)
-    xcresult (0.2.1)
+    xcresult (0.2.2)
     yard (0.9.36)
 
 PLATFORMS

--- a/danger-xcode_summary.gemspec
+++ b/danger-xcode_summary.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.4.0"
 
-  spec.add_dependency 'xcresult', '~> 0.2'
+  spec.add_dependency 'xcresult', '~> 0.2.2'
   spec.add_runtime_dependency 'danger-plugin-api', '~> 1.0'
 
   # General ruby development


### PR DESCRIPTION
Updates `xcresult` to [0.2.2](https://github.com/fastlane-community/xcresult/releases/tag/0.2.2) which fixes `xcresulttool` usages by applying the `--legacy` flag

This solves #91 