### PR TITLE
Fix CGI.parse not found in Ruby 4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        ruby-version: ['3.2.2']
+        ruby-version: ['latest']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        ruby-version: ['latest']
+        ruby-version: ['3.4', '4.0']
 
     steps:
     - uses: actions/checkout@v3

--- a/danger-xcode_summary.gemspec
+++ b/danger-xcode_summary.gemspec
@@ -24,21 +24,21 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.4.0'
 
   spec.add_dependency 'danger-plugin-api', '~> 1.0'
-  spec.add_dependency 'xcresult', '~> 0.2.2'
+  spec.add_dependency 'xcresult'
 
   # General ruby development
   spec.add_development_dependency 'bundler', '>= 2.2.10'
-  spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'rake'
 
   #  Testing support
-  spec.add_development_dependency 'rspec', '~> 3.4'
+  spec.add_development_dependency 'rspec'
 
   # Makes testing easy via `bundle exec guard`
-  spec.add_development_dependency 'guard', '~> 2.14'
-  spec.add_development_dependency 'guard-rspec', '~> 4.7'
+  spec.add_development_dependency 'guard'
+  spec.add_development_dependency 'guard-rspec'
 
   # If you want to work on older builds of ruby
-  spec.add_development_dependency 'listen', '~> 3.0'
+  spec.add_development_dependency 'listen'
 
   # This gives you the chance to run a REPL inside your test
   # via

--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -400,7 +400,7 @@ module Danger
       file_path = document_location.url.gsub('file://', '').split('#').first
       file_name = file_path.split('/').last
       fragment = document_location.url.split('#').last
-      params = CGI.parse(fragment).transform_values(&:first)
+      params = URI.decode_www_form(fragment).to_h
       line_number = params['StartingLineNumber']
       # StartingLineNumber is 0-based, but we need a 1-based value
       line = line_number.nil? || line_number.empty? ? 0 : line_number.to_i + 1

--- a/spec/xcode_summary_spec.rb
+++ b/spec/xcode_summary_spec.rb
@@ -213,7 +213,7 @@ module Danger
         context 'with sort_warnings_by' do
           before do
             @xcode_summary.sort_warnings_by do |warning|
-              warning.message.include?('TODOs') ? 0 : 1
+              "#{warning.message.include?('TODOs') ? 0 : 1}_#{warning&.location&.file_path}/#{warning&.location&.file_name}:#{warning&.location&.line}/"
             end
           end
           it 'sorts compile warnings' do


### PR DESCRIPTION
In ruby 4 CGi.parse no longer exists. This PR fixes that, and updates the tests to be sort stable.